### PR TITLE
Update away from deprecated names in latest Savi version.

### DIFF
--- a/src/TCP.Engine.savi
+++ b/src/TCP.Engine.savi
@@ -59,7 +59,7 @@
 
   :fun ref pending_reads
     :yields USize for None
-    if Platform.windows (
+    if Platform.is_windows (
       None // TODO: @_windows_complete_reads(arg)
     |
       @_pending_reads_unix -> (bytes_available | yield bytes_available)

--- a/src/TCP.Listen.Engine.savi
+++ b/src/TCP.Listen.Engine.savi
@@ -46,7 +46,7 @@
 
   :fun ref pending_connections
     :yields TCP.Accept.Ticket for None
-    if Platform.windows (
+    if Platform.is_windows (
       None // TODO
     |
       if @_closed.not (
@@ -84,7 +84,7 @@
   :fun ref close
     if (@_closed.not && @_event.is_not_null) (
       // When not on windows, unsubscribe immediately here instead of later.
-      if Platform.windows.not AsioEvent.unsubscribe(@_event)
+      if Platform.is_windows.not AsioEvent.unsubscribe(@_event)
 
       _LibPonyOS.pony_os_socket_close(@_fd)
       @_fd = -1

--- a/src/_Lib.savi
+++ b/src/_Lib.savi
@@ -1,8 +1,8 @@
-:ffi _LibC
+:ffimodule _LibC
   :fun ntohs(network_short U16) U16
   :fun ntohl(network_long U32) U32
 
-:ffi _LibPonyOS
+:ffimodule _LibPonyOS
   :fun pony_os_listen_tcp(owner AsioEventNotify, host CPointer(U8), service CPointer(U8)) CPointer(AsioEvent)
   :fun pony_os_accept(event CPointer(AsioEvent)) U32
   :fun pony_os_socket_close(fd U32) None

--- a/src/_NetAddress.savi
+++ b/src/_NetAddress.savi
@@ -21,7 +21,7 @@
   :fun scope:     _LibC.ntohl(@_scope) // (converted to host byte order)
   :fun ipv4_addr: _LibC.ntohl(@_ipv4) // (converted to host byte order)
   // TODO: ipv6_addr (needs tuple return value)
-  // TODO: family (needs Platform.big_endian)
+  // TODO: family (needs Platform.is_big_endian)
 
   :fun "=="(other _NetAddress'box)
     @_family == other._family


### PR DESCRIPTION
- Prefer `:ffimodule` over `:ffi`.
- Prefer `Platform.is_windows` over `Platform.windows`.